### PR TITLE
Fix build of text/expr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ EG = \
   eg/string \
   eg/oddeven \
   eg/plus-abs \
-  eg/pretty \
   eg/ratio \
   eg/sets \
   eg/tauts \
@@ -55,6 +54,7 @@ EG = \
   bench/trilean \
   bench/unit
 EXTRAEG = \
+  eg/pretty \
   eg/regexes \
   eg/pretty-compact \
   eg/algebraic-graphs

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # License:     3-Clause BSD  (see the file LICENSE)
 # Maintainer:  Rudy Matela <rudy@matela.com.br>
 GHCIMPORTDIRS = src:eg:test
-GHCFLAGS = -O2 \
+GHCFLAGS = -O2 -v0 \
   $(shell grep -q "Arch Linux" /etc/lsb-release && echo -dynamic -package cmdargs -package regex-tdfa)
 # -Wall -Wno-name-shadowing -Wno-orphans -Wno-unused-matches
 # -prof -auto-all #-caf-all

--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,8 @@ Changelog for Speculate
 =======================
 
 
-v0.4.14
--------
+v0.4.14 (September 2021)
+------------------------
 
 * `Test.Speculate.Reason`: add `doubleCheck`;
 * add `lowtests` benchmark;
@@ -11,23 +11,23 @@ v0.4.14
 * fix parallel compilation when using the Makefile.
 
 
-v0.4.12
--------
+v0.4.12 (July 2021)
+-------------------
 
 * bump [express] requirement to v0.2.0
 * add this changelog
 
 
-v0.4.10
--------
+v0.4.10 (June 2021)
+-------------------
 
 * no changes in the actual [Speculate] library
 * cleanup build files
 * remove uneeded typeable derivations on examples and tests
 
 
-v0.4.8
-------
+v0.4.8 (June 2021)
+------------------
 
 * no changes in the actual [Speculate] library
 * refactor build scripts
@@ -35,8 +35,8 @@ v0.4.8
 * fix compilation of some examples under the new [LeanCheck]
 
 
-v0.4.6
-------
+v0.4.6 (April 2021)
+-------------------
 
 * [`Test.Speculate`]: export `reifyName`;
 * "internal" modules:

--- a/test/expr.hs
+++ b/test/expr.hs
@@ -57,15 +57,19 @@ tests n =
             , (yy,ff2 xx xx)
             ]
   ]
+  where
+  -- now uneeded as Data.Express.Fixtures exports something of sorts
+  ff2 :: Expr -> Expr -> Expr
+  ff2 e1 e2 = ffE :$ e1 :$ e2
+    where ffE = value "f" (undefined :: Int -> Int -> Int)
+  -- however there ffE = var "f" (...)
+  -- so I am keeping a local definition of ff2 here
+  -- to make it uniform with hh5 and hh7
 
-ff2 :: Expr -> Expr -> Expr
-ff2 e1 e2 = ffE :$ e1 :$ e2
-  where ffE = value "f" (undefined :: Int -> Int -> Int)
+  hh5 :: Expr -> Expr -> Expr -> Expr -> Expr -> Expr
+  hh5 e1 e2 e3 e4 e5 = hhE :$ e1 :$ e2 :$ e3 :$ e4 :$ e5
+    where hhE = value "h" (undefined :: Int -> Int -> Int -> Int -> Int -> Int)
 
-hh5 :: Expr -> Expr -> Expr -> Expr -> Expr -> Expr
-hh5 e1 e2 e3 e4 e5 = hhE :$ e1 :$ e2 :$ e3 :$ e4 :$ e5
-  where hhE = value "h" (undefined :: Int -> Int -> Int -> Int -> Int -> Int)
-
-hh7 :: Expr -> Expr -> Expr -> Expr -> Expr -> Expr -> Expr -> Expr
-hh7 e1 e2 e3 e4 e5 e6 e7 = hhE :$ e1 :$ e2 :$ e3 :$ e4 :$ e5 :$ e6 :$ e7
-  where hhE = value "h" (undefined :: Int -> Int -> Int -> Int -> Int -> Int -> Int -> Int)
+  hh7 :: Expr -> Expr -> Expr -> Expr -> Expr -> Expr -> Expr -> Expr
+  hh7 e1 e2 e3 e4 e5 e6 e7 = hhE :$ e1 :$ e2 :$ e3 :$ e4 :$ e5 :$ e6 :$ e7
+    where hhE = value "h" (undefined :: Int -> Int -> Int -> Int -> Int -> Int -> Int -> Int)


### PR DESCRIPTION
This PR fixes the build of test/expr, c.f.: #12.

... along with the CI build on recent GHC versions.